### PR TITLE
Add new elevator, escalator and steps icons

### DIFF
--- a/mapicons/indoorequal-elevator.svg
+++ b/mapicons/indoorequal-elevator.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="18px" height="18px" viewBox="0 0 18 18" enable-background="new 0 0 18 18" xml:space="preserve">
+  <circle fill="#828686" stroke="#FFFFFF" stroke-width="0.5" stroke-miterlimit="10" cx="9" cy="9" r="8.75" />
+  <rect x="3.5" y="7.5" fill="#828686" stroke="#FFFFFF" stroke-miterlimit="10" width="11" height="6" />
+  <g>
+    <line fill="#828686" x1="6" y1="9" x2="6" y2="12" />
+    <g>
+      <path fill="#FFFFFF" d="M5.5,9c0,1,0,2,0,3c0,0.35,1,0.35,1,0c0-1,0-2,0-3C6.5,8.65,5.5,8.65,5.5,9L5.5,9z" />
+    </g>
+  </g>
+  <g>
+    <line fill="#828686" x1="9" y1="9" x2="9" y2="12" />
+    <g>
+      <path fill="#FFFFFF" d="M8.5,9c0,1,0,2,0,3c0,0.35,1,0.35,1,0c0-1,0-2,0-3C9.5,8.65,8.5,8.65,8.5,9L8.5,9z" />
+    </g>
+  </g>
+  <g>
+    <line fill="#828686" x1="12" y1="9" x2="12" y2="12" />
+    <g>
+      <path fill="#FFFFFF" d="M11.5,9c0,1,0,2,0,3c0,0.35,1,0.35,1,0c0-1,0-2,0-3C12.5,8.65,11.5,8.65,11.5,9L11.5,9z" />
+    </g>
+  </g>
+  <polyline fill="#828686" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="5.5,3 
+    5.5,6 4,4.5 5.5,6 7,4.5 	" />
+  <polyline fill="#828686" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="12.5,6 
+    12.5,3 11,4.5 12.5,3 14,4.5 	" />
+</svg>

--- a/mapicons/indoorequal-escalator.svg
+++ b/mapicons/indoorequal-escalator.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="18px" height="18px" viewBox="0 0 18 18" enable-background="new 0 0 18 18" xml:space="preserve">
+  <path fill="#828686" stroke="#FFFFFF" stroke-width="0.5" stroke-miterlimit="10" d="M17.75,9c0,4.834-3.917,8.75-8.751,8.75
+    c-4.835,0-8.75-3.916-8.75-8.75s3.914-8.75,8.75-8.75C13.833,0.25,17.75,4.167,17.75,9z" />
+  <path fill="#828686" stroke="#FFFFFF" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M4.5,10
+    c1,0,0,0,1.5,0s3-5,4.5-5s1.5,0,3,0s1.5,3,0,3c-1,0,0,0-1.5,0s-3,5-4.5,5s-1.5,0-3,0S3,10,4.5,10z" />
+</svg>

--- a/mapicons/indoorequal-steps.svg
+++ b/mapicons/indoorequal-steps.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="18px" height="18px" viewBox="0 0 18 18" enable-background="new 0 0 18 18" xml:space="preserve">
+  <circle fill="#828686" stroke="#FFFFFF" stroke-width="0.5" stroke-miterlimit="10" cx="9" cy="9" r="8.75" />
+  <polyline fill="#828686" stroke="#FFFFFF" stroke-miterlimit="10" points="6.5,13.5 6.5,10.5 9.5,10.5 9.5,7.5 12.5,7.5 12.5,4.5" />
+</svg>


### PR DESCRIPTION
Hi,

Thank you for your amazing project! I hope it will help the community to contribute more indoor on the indoor!

This PR adds new icons, elevator, escalator and steps. I choose to name them with `indoorequal` prefix in order to avoid conflicts with basemap icons. If this is not OK, we can change it.

New icons will have a circle, this makes it easier to see that they are interactive.

Sprite with new icons:
![sprite@2x](https://user-images.githubusercontent.com/5153882/88299245-71237800-cd02-11ea-88db-1d3ee45425d0.png)
