### PR TITLE
Fix the spelling of "wheelchair"

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -463,7 +463,7 @@
   "wheelchair": {
     "limited": "Limited accessibility",
     "no": "Not accessible",
-    "yes": "Weelchair accessible"
+    "yes": "Wheelchair accessible"
   },
   "zoom": "Zoom in to see indoor data"
 }


### PR DESCRIPTION
There's an "h" in the correct spelling in English